### PR TITLE
REDME.md: Fixed branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Web site for chaos development.
 
 Repository structure:
 
-- `master` branch: Holds the source code for the web site.
-- `gh-pages` branch: Holds the "compiled" version of the web site, that is published to e.g. http://chaosdev.io and http://chaos4ever.github.io
+- `src` branch: Holds the source code for the web site.
+- `master` branch: Holds the "compiled" version of the web site, that is published to e.g. http://chaosdev.io and http://chaos4ever.github.io
 
 To publish updated versions of the site, use the `publish.sh` script. It makes certain rough assumptions of the folder structured on your machine; see the script for the full details.


### PR DESCRIPTION
Forgive my silly mistake. It turned out that for _organization_ pages, you cannot have a `gh-pages` branch; it will _not be used_, even though it exists. Ridiculous indeed, but... what do you do. So let's change back the branch names to what it was before tonight.
